### PR TITLE
Remove forking on deactivation

### DIFF
--- a/lib/kill-all.js
+++ b/lib/kill-all.js
@@ -1,9 +1,0 @@
-'use strict';
-
-var kill = require('tree-kill');
-
-process.argv.slice(2).forEach(function(pid) {
-  kill(pid, 'SIGKILL', function(err) {
-    if (err) console.error(err);
-  });
-});

--- a/lib/status-view.coffee
+++ b/lib/status-view.coffee
@@ -69,10 +69,7 @@ class StatusView extends View
   # Tear down any state and remove
   destroy: ->
     for index in [@termViews.length - 1 .. 0] by -1
-      @termViews[index].destroy false
-    if @termViews.length
-      pids = (termView.program.pid for termView in @termViews)
-      require('child_process').fork(__dirname + '/kill-all.js', pids).unref()
+      @termViews[index].destroy()
     @remove()
     @subs.dispose()
 

--- a/lib/term-view.coffee
+++ b/lib/term-view.coffee
@@ -31,7 +31,7 @@ class TermView extends View
             @span 'Clear'
           @button click: 'close', class: 'btn', title: 'Hide the terminal (Shift+Enter)', =>
             @span 'Hide'
-          @button click: 'quit', class: 'btn', title: 'Kill the running process (if any) and destroy the terminal session', =>
+          @button click: 'destroy', class: 'btn', title: 'Kill the running process (if any) and destroy the terminal session', =>
             @span 'Quit'
       @div class: 'cli-panel-body', =>
         @pre tabIndex: -1, class: 'terminal native-key-bindings', outlet: 'cliOutput',
@@ -116,9 +116,6 @@ class TermView extends View
       @kill()
     else
       _destroy()
-
-  quit: ->
-    @destroy()
 
   kill: ->
     if @program

--- a/lib/term-view.coffee
+++ b/lib/term-view.coffee
@@ -105,7 +105,7 @@ class TermView extends View
     clearTimeout @statusIconFlashTimeout if @statusIconFlashTimeout
     @statusIcon.classList.remove 'status-running', 'status-info', 'status-success', 'status-error'
 
-  destroy: (doKill = true) ->
+  destroy: ->
     _destroy = =>
       @close() if @hasParent()
       @statusIcon.parentNode.removeChild @statusIcon
@@ -113,7 +113,7 @@ class TermView extends View
       @subs.dispose()
     if @program
       @program.once 'exit', _destroy
-      @kill() if doKill
+      @kill()
     else
       _destroy()
 


### PR DESCRIPTION
It looks like forking is no longer necessary.

All of these actions properly kill the entire process tree (tested on OS X): reloading Atom, closing Atom window, Cmd+Q, deactivating package.

I'll test a bit more on Windows before merging. This task is much more straightforward and less error-prone in Windows, so hopefully there won't be any issues.
